### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kruler.json
+++ b/org.kde.kruler.json
@@ -11,6 +11,9 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+     "cleanup": [
+        "/share/doc"
+    ],
     "modules": [
         {
             "name": "kruler",


### PR DESCRIPTION
The installed size reduced from 523.3 kB to 225.8 kB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.